### PR TITLE
Enable API key review and format help

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,14 @@ Check out the demo here:
 
 
 ### Version 1.6 -  [PR](https://github.com/sebhs/human-reader-chrome-extension/pull/31)
-New features: 
+New features:
 - Allowing users to stop audio from playing
 - Adding support for Turbo v2.5
+
+### Version 1.7
+New features:
+- Accept multiple API keys separated by commas or new lines
+- Rotate keys automatically and fetch available models dynamically
 
 ### Version 1.3 -  [PR](https://github.com/sebhs/human-reader-chrome-extension/pull/24)
 New features: 

--- a/content.js
+++ b/content.js
@@ -43,8 +43,22 @@ const readStorage = async (keys) => {
   });
 };
 
+const getNextApiKey = async () => {
+  const storage = await readStorage(["apiKeys", "apiKeyIndex", "apiKey"]);
+  if (storage.apiKeys && storage.apiKeys.length > 0) {
+    const index = storage.apiKeyIndex || 0;
+    const apiKey = storage.apiKeys[index % storage.apiKeys.length];
+    await chrome.storage.local.set({
+      apiKeyIndex: (index + 1) % storage.apiKeys.length,
+    });
+    return apiKey;
+  }
+  return storage.apiKey;
+};
+
 const fetchResponse = async () => {
-  const storage = await readStorage(["apiKey", "selectedVoiceId", "mode"]);
+  const storage = await readStorage(["selectedVoiceId", "mode"]);
+  const apiKey = await getNextApiKey();
   const selectedVoiceId = storage.selectedVoiceId
     ? storage.selectedVoiceId
     : "21m00Tcm4TlvDq8ikWAM"; //fallback Voice ID
@@ -60,7 +74,7 @@ const fetchResponse = async () => {
       method: "POST",
       headers: {
         Accept: codec,
-        "xi-api-key": storage.apiKey,
+        "xi-api-key": apiKey,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
@@ -111,8 +125,8 @@ const stopAudio = () => {
 
 let sourceOpenEventAdded = false;
 const streamAudio = async () => {
-  const storage = await readStorage(["apiKey", "speed"]);
-  if (!storage.apiKey) {
+  const storage = await readStorage(["apiKeys", "apiKey", "speed"]);
+  if (!((storage.apiKeys && storage.apiKeys.length > 0) || storage.apiKey)) {
     handleMissingApiKey();
     return;
   }

--- a/popup.css
+++ b/popup.css
@@ -61,7 +61,8 @@ label {
 }
 
 input,
-select {
+select,
+textarea {
   flex: 2;
   margin-left: 12px;
   padding: 4px;

--- a/popup.html
+++ b/popup.html
@@ -23,11 +23,7 @@
       </div>
       <div class="settingsItemNoPadding">
         <label for="mode">Model:</label>
-        <select id="mode">
-          <option value="eleven_turbo_v2">Turbo v2</option>
-          <option value="eleven_turbo_v2_5">Turbo v2.5</option>
-          <option value="eleven_multilingual_v2">Multilingual v2</option>
-        </select>
+        <select id="mode"></select>
       </div>
       <div class="settingsItemNoPadding">
         <p>
@@ -64,6 +60,10 @@
           <option value="2.5" label="2.5x"></option>
         </datalist>
       </div>
+      <div class="settingsItem">
+        <label for="storedApiKeys">API Keys:</label>
+        <textarea id="storedApiKeys" rows="2" readonly></textarea>
+      </div>
       <div class="clearStorage">
         <a href="#" id="clearStorage">Clear all data</a>
       </div>
@@ -90,12 +90,13 @@
             >
           </li>
           <li>Paste the API key into the input field below</li>
+          <li>Multiple keys can be separated by commas or new lines</li>
           <li>Click "Set" to get started</li>
         </ul>
       </div>
       <div class="welcomeInput">
-        <label for="apiKey">API Key:</label>
-        <input type="text" id="apiKey" />
+        <label for="apiKey">API Key(s):</label>
+        <input type="text" id="apiKey" placeholder="key1,key2,..." />
         <button id="setApiKey">Set</button>
       </div>
     </div>

--- a/popup.js
+++ b/popup.js
@@ -18,6 +18,20 @@ const readStorage = async (keys) => {
   });
 };
 
+const getNextApiKey = async () => {
+  const storage = await readStorage(["apiKeys", "apiKeyIndex", "apiKey"]);
+  if (storage.apiKeys && storage.apiKeys.length > 0) {
+    const index = storage.apiKeyIndex || 0;
+    const apiKey = storage.apiKeys[index % storage.apiKeys.length];
+    await setStorageItem(
+      "apiKeyIndex",
+      (index + 1) % storage.apiKeys.length
+    );
+    return apiKey;
+  }
+  return storage.apiKey;
+};
+
 const setWelcomeScreen = () => {
   const settings = document.getElementById("settings");
   const welcome = document.getElementById("welcome");
@@ -39,6 +53,7 @@ const setSettingsScreen = async () => {
   storage = await readStorage(["mode", "speed"]);
   document.getElementById("mode").value = storage.mode;
   setSpeedValue(storage.speed || 1);
+  await populateApiKeys();
 };
 
 const setSpeedValue = (value) => {
@@ -47,6 +62,7 @@ const setSpeedValue = (value) => {
 };
 
 const loadStartupData = async () => {
+  await fetchModels();
   const voices = await fetchVoices();
   storage = await readStorage([
     "apiKey",
@@ -84,28 +100,93 @@ const populateVoices = async () => {
   }
 };
 
-const setAPIKey = async (apiKey) => {
-  const response = await fetch("https://api.elevenlabs.io/v1/user", {
-    method: "GET",
-    headers: {
-      "xi-api-key": apiKey,
-      "Content-Type": "application/json",
-    },
-  });
-  if (response.ok) {
-    await setStorageItem("apiKey", apiKey);
-  } else {
+const populateModels = async () => {
+  const storage = await readStorage(["models", "mode"]);
+  const models = storage.models;
+  if (models) {
+    const select = document.getElementById("mode");
+    select.innerHTML = "";
+    models.forEach((m) => {
+      const option = document.createElement("option");
+      option.value = m.id;
+      option.text = m.name;
+      select.appendChild(option);
+    });
+    if (storage.mode) select.value = storage.mode;
+  }
+};
+
+const populateApiKeys = async () => {
+  const storage = await readStorage(["apiKeys", "apiKey"]);
+  const field = document.getElementById("storedApiKeys");
+  if (field) {
+    const keys =
+      storage.apiKeys && storage.apiKeys.length > 0
+        ? storage.apiKeys.join("\n")
+        : storage.apiKey || "";
+    field.value = keys;
+  }
+};
+
+const setAPIKeys = async (apiKeysInput) => {
+  const keys = apiKeysInput
+    .split(/[,\n]+/)
+    .map((k) => k.trim())
+    .filter((k) => k);
+  const validKeys = [];
+  for (const key of keys) {
+    const response = await fetch("https://api.elevenlabs.io/v1/user", {
+      method: "GET",
+      headers: {
+        "xi-api-key": key,
+        "Content-Type": "application/json",
+      },
+    });
+    if (response.ok) {
+      validKeys.push(key);
+    }
+  }
+  if (validKeys.length === 0) {
     throw new Error("API request failed");
+  }
+  await setStorageItem("apiKeys", validKeys);
+  await setStorageItem("apiKeyIndex", 0);
+  await setStorageItem("apiKey", validKeys[0]);
+};
+
+const fetchModels = async () => {
+  const apiKey = await getNextApiKey();
+  if (apiKey) {
+    let response = await fetch("https://api.elevenlabs.io/v1/models", {
+      method: "GET",
+      headers: {
+        "xi-api-key": apiKey,
+        "Content-Type": "application/json",
+      },
+    });
+    if (response.ok) {
+      const data = await response.json();
+      if (data.models) {
+        const models = data.models.map((m) => ({
+          id: m.model_id,
+          name: m.name,
+        }));
+        await setStorageItem("models", models);
+        await populateModels();
+        return models;
+      }
+    }
   }
 };
 
 const fetchVoices = async () => {
-  const storage = await readStorage(["apiKey", "selectedVoiceId", "mode"]);
-  if (storage.apiKey) {
+  const storage = await readStorage(["selectedVoiceId", "mode"]);
+  const apiKey = await getNextApiKey();
+  if (apiKey) {
     let response = await fetch("https://api.elevenlabs.io/v1/voices", {
       method: "GET",
       headers: {
-        "xi-api-key": storage.apiKey,
+        "xi-api-key": apiKey,
         "Content-Type": "application/json",
       },
     });
@@ -134,9 +215,11 @@ const fetchVoices = async () => {
 };
 
 document.addEventListener("DOMContentLoaded", async () => {
-  const storage = await readStorage(["apiKey"]);
-  if (storage.apiKey) {
+  const storage = await readStorage(["apiKeys", "apiKey"]);
+  if ((storage.apiKeys && storage.apiKeys.length > 0) || storage.apiKey) {
     populateVoices();
+    populateModels();
+    populateApiKeys();
     setSettingsScreen();
   } else {
     setWelcomeScreen();
@@ -154,9 +237,10 @@ document.getElementById("setApiKey").addEventListener("click", async () => {
   const inputValue = document.getElementById("apiKey").value;
   button.textContent = "...";
   try {
-    await setAPIKey(inputValue);
+    await setAPIKeys(inputValue);
     await loadStartupData();
     await setSettingsScreen();
+    await populateApiKeys();
     button.textContent = "Set";
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
## Summary
- document multiple API key support in README
- show instructions for comma/newline separated keys in the popup
- display stored API keys in settings

## Testing
- `node -c popup.js`
- `node -c content.js`


------
https://chatgpt.com/codex/tasks/task_e_6851546591548327804ea1bf1061d350